### PR TITLE
Add media handling to RawMaterial entity and service

### DIFF
--- a/src/main/java/com/stock_mate/BE/entity/RawMaterial.java
+++ b/src/main/java/com/stock_mate/BE/entity/RawMaterial.java
@@ -41,4 +41,25 @@ public class RawMaterial {
     @OneToMany(mappedBy = "rawMaterial")
     List<Stock> stocks;
 
+    @OneToMany(mappedBy = "rawMaterial", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<RawMaterialMedia> mediaList;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createDate = LocalDate.now();
+        this.updateDate = LocalDate.now();
+    }
+    @PreUpdate
+    protected void onUpdate() {
+        this.updateDate = LocalDate.now();
+    }
+
+    @PostLoad
+    public void setImage() {
+        if (mediaList == null || mediaList.isEmpty()) {
+            this.image = null;
+            return;
+        }
+        this.image = mediaList.get(0).getMediaUrl();
+    }
 }

--- a/src/main/java/com/stock_mate/BE/mapper/RawMaterialMapper.java
+++ b/src/main/java/com/stock_mate/BE/mapper/RawMaterialMapper.java
@@ -6,5 +6,6 @@ import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface RawMaterialMapper {
+
     RawMaterialResponse toDto(RawMaterial rawMaterial);
 }

--- a/src/main/java/com/stock_mate/BE/service/RawMaterialService.java
+++ b/src/main/java/com/stock_mate/BE/service/RawMaterialService.java
@@ -36,6 +36,13 @@ public class RawMaterialService {
     //Lấy tất cả vật tư
     public List<RawMaterialResponse> getAllRawMaterials() {
         var list = rawMaterialRepository.findAll();
+
+        list.forEach(rm -> {
+            List<RawMaterialMedia> mediaList =
+                    rawMaterialMediaRepository.findByRawMaterial_RmID(rm.getRmID());
+            rm.setMediaList(mediaList);
+        });
+
         return list.stream().map(rawMaterialMapper::toDto).toList();
     }
 


### PR DESCRIPTION
Introduced mediaList to RawMaterial and updated lifecycle hooks to manage image assignment. RawMaterialService now loads associated media for each raw material, ensuring image data is set before mapping to DTO.